### PR TITLE
Ugly hack to enable filtering by the presence of annotations.

### DIFF
--- a/backend/api/views/example.py
+++ b/backend/api/views/example.py
@@ -20,7 +20,7 @@ class ExampleList(generics.ListCreateAPIView):
     ordering_fields = ('created_at', 'updated_at')
     search_fields = ('text', 'filename')
     model = Example
-    filter_class = ExampleFilter
+    filter_class = DocumentFilter
 
     @property
     def project(self):

--- a/frontend/repositories/example/apiDocumentRepository.ts
+++ b/frontend/repositories/example/apiDocumentRepository.ts
@@ -9,7 +9,7 @@ export class APIExampleRepository implements ExampleRepository {
   ) {}
 
   async list(projectId: string, { limit = '10', offset = '0', q = '', isChecked = '' }: SearchOption): Promise<ExampleItemList> {
-    const url = `/projects/${projectId}/examples?limit=${limit}&offset=${offset}&q=${q}&confirmed=${isChecked}`
+    const url = `/projects/${projectId}/examples?limit=${limit}&offset=${offset}&q=${q}&categories__isnull=${isChecked}`
     const response = await this.request.get(url)
     return ExampleItemList.valueOf(response.data)
   }


### PR DESCRIPTION
This should be done more cleanly across the app. Revert this when upstream fixes it.